### PR TITLE
Add more configuration documentation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,42 @@ return [
 ];
 ``` 
 
+### Auth Configuration
+
+You can custom header of elastic client request by add params to the config php file like : 
+
+```php
+return [
+    'hosts' => [
+        env('ELASTIC_HOST', 'localhost:9200'),
+    ],
+    "connectionParams" => [
+        'client' => [
+            "headers" => [
+            ]
+        ]
+    ]
+];
+```
+
+For specify basic bearer authentification you can use 
+
+
+```php
+return [
+    'hosts' => [
+        env('ELASTIC_HOST', 'localhost:9200'),
+    ],
+    "connectionParams" => [
+        'client' => [
+            "headers" => [
+            'Authorization' => ["Basic {username:password}"]
+            ]
+        ]
+    ]
+];
+```
+
 ## Usage
 
 Type hint `\Elasticsearch\Client` or use `resolve` function to retrieve the client instance in your code:


### PR DESCRIPTION
Hey ! 

Some time ago I had to set up an elastic seach with basic authentication, and on the client side I used this package it was very useful to me but I realized that it was not not clear in the doc how to pass the bearer, so I allow myself to do a PR to adjust this.