### PR TITLE
[feature] AWS Elasticsearch Service support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     },
     "require": {
         "php": "^7.2",
-        "elasticsearch/elasticsearch": "^7.3"
+        "elasticsearch/elasticsearch": "^7.3",
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
     },
     "require": {
         "php": "^7.2",
+        "aws/aws-sdk-php": "^3.132",
         "elasticsearch/elasticsearch": "^7.3",
+        "guzzlehttp/guzzle": "^6.5|7.0",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/config/elastic.client.php
+++ b/config/elastic.client.php
@@ -1,7 +1,159 @@
 <?php declare(strict_types=1);
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | ElasticSearch Hosts
+    |--------------------------------------------------------------------------
+    |
+    | Define your hosts here.
+    |
+    */
+
     'hosts' => [
-        env('ELASTIC_HOST', 'localhost:9200'),
-    ]
+        [
+            'host' => env('ELASTIC_HOST', '127.0.0.1'),
+            'port' => env('ELASTIC_PORT', 9200),
+            'scheme' => env('ELASTIC_SCHEME', null),
+            'user' => env('ELASTIC_USER', null),
+            'pass' => env('ELASTIC_PASSWORD', null),
+
+            'aws_enable' => env('ELASTIC_USE_AWS', false),
+            'aws_region' => env('ELASTIC_AWS_REGION', 'us-east-1'),
+            'aws_key' => env('AWS_ACCESS_KEY_ID', ''),
+            'aws_secret' => env('AWS_SECRET_ACCESS_KEY', ''),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | SSL Verification
+    |--------------------------------------------------------------------------
+    |
+    | If your Elasticsearch instance uses an out-dated or self-signed SSL
+    | certificate, you will need to pass in the certificate bundle.  This can
+    | either be the path to the certificate file (for self-signed certs), or a
+    | package like https://github.com/Kdyby/CurlCaBundle.  See the documentation
+    | below for all the details.
+    |
+    | If you are using SSL instances, and the certificates are up-to-date and
+    | signed by a public certificate authority, then you can leave this null and
+    | just use "https" in the host path(s) above and you should be fine.
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_security.html#_ssl_encryption_2
+    |
+    */
+
+    'sslVerification' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Retries
+    |--------------------------------------------------------------------------
+    |
+    | By default, the client will retry n times, where n = number of nodes in
+    | your cluster. If you would like to disable retries, or change the number,
+    | you can do so here.
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_set_retries
+    |
+    */
+
+    'retries' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sniffing On Start
+    |--------------------------------------------------------------------------
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html
+    |
+    */
+
+    'sniffOnStart' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTP Handler
+    |--------------------------------------------------------------------------
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_configure_the_http_handler
+    | @see http://ringphp.readthedocs.org/en/latest/client_handlers.html
+    |
+    */
+
+    'httpHandler' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connection Pooling
+    |--------------------------------------------------------------------------
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_setting_the_connection_pool
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_connection_pool.html
+    |
+    */
+
+    'connectionPool' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connection Selector
+    |--------------------------------------------------------------------------
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_setting_the_connection_selector
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_selectors.html
+    |
+    */
+
+    'connectionSelector' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Response Serializer
+    |--------------------------------------------------------------------------
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_setting_the_serializer
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_serializers.html
+    |
+    */
+
+    'serializer' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connection Factory
+    |--------------------------------------------------------------------------
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_setting_a_custom_connectionfactory
+    |
+    */
+
+    'connectionFactory' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Endpoint Closure
+    |--------------------------------------------------------------------------
+    |
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/6.0/_configuration.html#_set_the_endpoint_closure
+    |
+    */
+
+    'endpoint' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Endpoint Closure
+    |--------------------------------------------------------------------------
+    |
+    | Register additional namespaces. Add an array of additional
+    | namespaces to register.
+    |
+    | @example 'namespaces' => [XPack::Security(), XPack::Watcher()]
+    | @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/ElasticsearchPHP_Endpoints.html#Elasticsearch_ClientBuilderregisterNamespace_registerNamespace
+    |
+    */
+
+    'namespaces' => [],
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -100,7 +100,7 @@ final class ServiceProvider extends AbstractServiceProvider
         // to authenticate through the V4 Signature before hitting the API.
         foreach ($config['hosts'] as $host) {
             if (isset($host['aws_enable']) && $host['aws_enable']) {
-                $clientBuilder->setHandler(function (array $request) use ($host) {
+                $clientBuilder->setHandler(static function (array $request) use ($host) {
                     $psr7Handler = \Aws\default_http_handler();
                     $signer = new SignatureV4('es', $host['aws_region']);
 
@@ -120,9 +120,9 @@ final class ServiceProvider extends AbstractServiceProvider
 
                     // Send the signed request to Amazon ES.
                     /** @var \Psr\Http\Message\ResponseInterface $response */
-                    $response = $psr7Handler($signedRequest)->then(function (\Psr\Http\Message\ResponseInterface $response) {
+                    $response = $psr7Handler($signedRequest)->then(static function (\Psr\Http\Message\ResponseInterface $response) {
                         return $response;
-                    }, function ($error) {
+                    }, static function ($error) {
                         return $error['response'];
                     })->wait();
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -78,11 +78,11 @@ final class ServiceProvider extends AbstractServiceProvider
     {
         $clientBuilder = ClientBuilder::create();
 
-        $clientBuilder->setHosts($connection['hosts']);
+        $clientBuilder->setHosts($config['hosts']);
 
         // Set additional client configuration
         foreach ($this->configMappings as $key => $method) {
-            $value = Arr::get($connection, $key);
+            $value = Arr::get($config, $key);
 
             if (is_array($value)) {
                 foreach ($value as $vItem) {
@@ -95,7 +95,7 @@ final class ServiceProvider extends AbstractServiceProvider
 
         // For each host, check if it uses AWS configuration and try to set a handler
         // to authenticate through the V4 Signature before hitting the API.
-        foreach ($connection['hosts'] as $host) {
+        foreach ($config['hosts'] as $host) {
             if (isset($host['aws_enable']) && $host['aws_enable']) {
                 $clientBuilder->setHandler(function (array $request) use ($host) {
                     $psr7Handler = \Aws\default_http_handler();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -74,9 +74,6 @@ final class ServiceProvider extends AbstractServiceProvider
         ]);
     }
 
-    /**
-     * @return Client
-     */
     protected function buildClientFromConfig(array $config): Client
     {
         $clientBuilder = ClientBuilder::create();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -74,7 +74,10 @@ final class ServiceProvider extends AbstractServiceProvider
         ]);
     }
 
-    protected function buildClientFromConfig(array $config)
+    /**
+     * @return Client
+     */
+    protected function buildClientFromConfig(array $config): Client
     {
         $clientBuilder = ClientBuilder::create();
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -57,7 +57,7 @@ final class ServiceProvider extends AbstractServiceProvider
             basename($this->configPath, '.php')
         );
 
-        $this->app->singleton(Client::class, static function () {
+        $this->app->singleton(Client::class, function () {
             $config = config('elastic.client');
 
             return $this->buildClientFromConfig($config);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,12 +2,36 @@
 
 namespace ElasticClient;
 
+use Aws\Credentials\Credentials;
+use Aws\Signature\SignatureV4;
 use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Ring\Future\CompletedFutureArray;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider as AbstractServiceProvider;
 
 final class ServiceProvider extends AbstractServiceProvider
 {
+    /**
+     * Map configuration array keys with ES ClientBuilder setters.
+     *
+     * @var array
+     */
+    protected $configMappings = [
+        'sslVerification' => 'setSSLVerification',
+        'sniffOnStart' => 'setSniffOnStart',
+        'retries' => 'setRetries',
+        'httpHandler' => 'setHandler',
+        'connectionPool' => 'setConnectionPool',
+        'connectionSelector' => 'setSelector',
+        'serializer' => 'setSerializer',
+        'connectionFactory'  => 'setConnectionFactory',
+        'endpoint' => 'setEndpoint',
+        'namespaces' => 'registerNamespace',
+    ];
+
     /**
      * @var string
      */
@@ -36,7 +60,7 @@ final class ServiceProvider extends AbstractServiceProvider
         $this->app->singleton(Client::class, static function () {
             $config = config('elastic.client');
 
-            return ClientBuilder::fromConfig($config);
+            return $this->buildClientFromConfig($config);
         });
     }
 
@@ -48,5 +72,69 @@ final class ServiceProvider extends AbstractServiceProvider
         $this->publishes([
             $this->configPath => config_path(basename($this->configPath)),
         ]);
+    }
+
+    protected function buildClientFromConfig(array $config)
+    {
+        $clientBuilder = ClientBuilder::create();
+
+        $clientBuilder->setHosts($connection['hosts']);
+
+        // Set additional client configuration
+        foreach ($this->configMappings as $key => $method) {
+            $value = Arr::get($connection, $key);
+
+            if (is_array($value)) {
+                foreach ($value as $vItem) {
+                    $clientBuilder->$method($vItem);
+                }
+            } elseif ($value !== null) {
+                $clientBuilder->$method($value);
+            }
+        }
+
+        // For each host, check if it uses AWS configuration and try to set a handler
+        // to authenticate through the V4 Signature before hitting the API.
+        foreach ($connection['hosts'] as $host) {
+            if (isset($host['aws_enable']) && $host['aws_enable']) {
+                $clientBuilder->setHandler(function (array $request) use ($host) {
+                    $psr7Handler = \Aws\default_http_handler();
+                    $signer = new SignatureV4('es', $host['aws_region']);
+
+                    // Create a PSR-7 request from the array passed to the handler.
+                    $psr7Request = new Request(
+                        $request['http_method'],
+                        (new Uri($request['uri']))->withScheme($request['scheme'])->withHost($request['headers']['Host'][0]),
+                        $request['headers'],
+                        $request['body']
+                    );
+
+                    // Sign the PSR-7 request with credentials from the environment.
+                    $signedRequest = $signer->signRequest(
+                        $psr7Request,
+                        new Credentials($host['aws_key'], $host['aws_secret'])
+                    );
+
+                    // Send the signed request to Amazon ES.
+                    /** @var \Psr\Http\Message\ResponseInterface $response */
+                    $response = $psr7Handler($signedRequest)->then(function (\Psr\Http\Message\ResponseInterface $response) {
+                        return $response;
+                    }, function ($error) {
+                        return $error['response'];
+                    })->wait();
+
+                    // Convert the PSR-7 response to a RingPHP response
+                    return new CompletedFutureArray([
+                        'status' => $response->getStatusCode(),
+                        'headers' => $response->getHeaders(),
+                        'body' => $response->getBody()->detach(),
+                        'transfer_stats' => ['total_time' => 0],
+                        'effective_url' => (string) $psr7Request->getUri(),
+                    ]);
+                });
+            }
+        }
+
+        return $clientBuilder->build();
     }
 }

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -18,7 +18,7 @@ class ServiceProviderTest extends TestCase
         $connection = $client->transport->getConnection();
 
         $this->assertInstanceOf(Client::class, $client);
-        $this->assertSame('localhost', $connection->getHost());
+        $this->assertSame('127.0.0.1', $connection->getHost());
         $this->assertSame(9200, $connection->getPort());
     }
 


### PR DESCRIPTION
First of all, I can say that the Elasticsearch ecosystem you built is great. I have tried to re-write it a while ago, [but I failed miserabily](https://github.com/renoki-co/elasticscout). All props to this. 

I have decided to take a part of it, like the [AWS Elasticsearch authentication through the client](https://github.com/renoki-co/elasticscout/blob/master/src/ElasticScoutServiceProvider.php#L87-L154), and merge it here.

The idea was initially forked from [cviebrock/laravel-elasticsearch](https://github.com/cviebrock/laravel-elasticsearch/blob/master/config/elasticsearch.php#L42-L58), then later merged in elastcscout, now it is here.

Not sure how to properly test this out. This was hard-tested on live AWS Elasticsearch Service.