### PR TITLE
Add connection params timeout to prevent infinite timeouts

### DIFF
--- a/config/elastic.client.php
+++ b/config/elastic.client.php
@@ -3,5 +3,12 @@
 return [
     'hosts' => [
         env('ELASTIC_HOST', 'localhost:9200'),
-    ]
+    ],
+
+    'connectionParams' => [
+        'client' => [
+            'timeout' => env('ELASTIC_TIMEOUT'),
+            'connect_timeout' => env('ELASTIC_CONNECT_TIMEOUT'),
+        ],
+    ],
 ];


### PR DESCRIPTION
We recently encountered an issue with our ES server being down and Scout indexing jobs timing out by PHP's script timeout setting (which was set to a very high).

By default, the ES client uses Guzzle with an infinite connect and request timeout. I've added these options in the configuration with null defaults so there are no breaking changes.

This will encourage other devs to set timeouts so they don't encounter this issue and spend the time I have debugging 😅 