### PR TITLE
Swap usage of `ClientInterface` instead of `Client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ return [
 If you need more control over the client creation, you can create your own client builder:
 
 ```php
-// see Elastic\Client\ClientBuilder for the reference
-class MyClientBuilder implements Elastic\Client\ClientBuilderInterface
+use Elastic\Elasticsearch\ClientInterface;
+use Elastic\Client\ClientBuilderInterface;
+
+class MyClientBuilder implements ClientBuilderInterface
 {
-    public function default(): Client
+    public function default(): ClientInterface
     {
         // should return a client instance for the default connection 
     }
     
-    public function connection(string $name): Client
+    public function connection(string $name): ClientInterface
     {
         // should return a client instance for the connection with the given name 
     }
@@ -109,7 +111,7 @@ Use `Elastic\Client\ClientBuilderInterface` to get access to the client instance
 ```php
 namespace App\Console\Commands;
 
-use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
 use Elastic\Client\ClientBuilderInterface;
 use Illuminate\Console\Command;
 

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Elastic\Client;
 
-use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
 use Elastic\Elasticsearch\ClientBuilder as BaseClientBuilder;
 use ErrorException;
 
@@ -10,7 +10,7 @@ class ClientBuilder implements ClientBuilderInterface
 {
     protected array $cache;
 
-    public function default(): Client
+    public function default(): ClientInterface
     {
         $name = config('elastic.client.default');
 
@@ -21,7 +21,7 @@ class ClientBuilder implements ClientBuilderInterface
         return $this->connection($name);
     }
 
-    public function connection(string $name): Client
+    public function connection(string $name): ClientInterface
     {
         if (isset($this->cache[$name])) {
             return $this->cache[$name];

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -2,11 +2,11 @@
 
 namespace Elastic\Client;
 
-use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
 
 interface ClientBuilderInterface
 {
-    public function default(): Client;
+    public function default(): ClientInterface;
 
-    public function connection(string $name): Client;
+    public function connection(string $name): ClientInterface;
 }

--- a/tests/Unit/ClientBuilderTest.php
+++ b/tests/Unit/ClientBuilderTest.php
@@ -3,7 +3,7 @@
 namespace Elastic\Client\Tests\Unit;
 
 use Elastic\Client\ClientBuilder;
-use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
 use ErrorException;
 use Orchestra\Testbench\TestCase;
 
@@ -51,7 +51,7 @@ final class ClientBuilderTest extends TestCase
         $this->clientBuilder->connection('foo');
     }
 
-    private function assertHost(Client $client, string $host): void
+    private function assertHost(ClientInterface $client, string $host): void
     {
         $transport = $client->getTransport();
         $node = $transport->getNodePool()->nextNode();


### PR DESCRIPTION
This PR swaps references to the Elasticsearch PHP package's `final Client` to its new v8.0 `ClientInterface` so that different implementations, fakes, and mocks can be returned for a bit easier testing.

This will likely require a new major version, but wanted to push it in case you're interested.

Let me know if you'd like anything changed. Thanks so much for your time! ❤️ 