### PR TITLE
Add support for elasticsearch 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require": {
         "php": "^8.2",
-        "elasticsearch/elasticsearch": "^8.0"
+        "elasticsearch/elasticsearch": "^8.0 || ^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.0",


### PR DESCRIPTION
This PR adds support for `elasticsearch` 9.x.

According to the [breaking changes](https://github.com/elastic/elasticsearch-php/blob/main/BREAKING_CHANGES.md#90), the only update is the new PHP 8.1+ requirement, which this project already satisfies.